### PR TITLE
Improve docker image

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -2,19 +2,17 @@ name: Jekyll site build tests
 
 on:
   push:
-    branches: [ "main", "gh_workflows", "content" ]
+    branches: ["gh_workflows", "content"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Build the site in the jekyll/builder container
-      run: |
-        docker run \
-        -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
-        jekyll/builder:latest /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"
+      - uses: actions/checkout@v4
+      - name: Build the site in the jekyll/builder container
+        run: |
+          docker run \
+          -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
+          jekyll/builder:latest /bin/bash -c "chmod -R 777 /srv/jekyll && jekyll build --future"

--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -2,8 +2,7 @@ name: Deploy to ghcr
 
 on:
   push:
-    branches: [ "main" ]
-
+    branches: ["main"]
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
@@ -18,7 +17,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -44,4 +43,3 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-    

--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
@@ -41,5 +42,7 @@ jobs:
         with:
           context: .
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ COPY site/ /site/
 RUN --mount=type=cache,target=/site/.jekyll-cache \
     JEKYLL_ENV=production bundle exec jekyll build
 
-FROM nginx:alpine
+FROM nginxinc/nginx-unprivileged:alpine
 COPY --from=builder /site/_site /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/root/.gem \
 COPY site/ /site/
 
 RUN --mount=type=cache,target=/site/.jekyll-cache \
-    bundle exec jekyll build
+    JEKYLL_ENV=production bundle exec jekyll build
 
 FROM nginx:alpine
 COPY --from=builder /site/_site /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,18 @@
-FROM alpine:latest
+FROM alpine:latest AS builder
+
+RUN --mount=type=cache,id=apk-cache,sharing=locked,target=/var/cache/apk \
+    apk --update add ruby bash git build-base ruby-dev libffi-dev
+
+WORKDIR /site
+COPY site/Gemfile* /site/
+
+RUN --mount=type=cache,target=/root/.gem \
+    gem install bundler && bundle install
 
 COPY site/ /site/
 
-WORKDIR /site
+RUN --mount=type=cache,target=/site/.jekyll-cache \
+    bundle exec jekyll build
 
-RUN rm -rf .jekyll-cache 
-
-RUN apk update && apk upgrade
-RUN apk add --update ruby bash \
-    && apk add git \
-    && apk add --virtual build-dependencies build-base ruby-dev libffi-dev \
-    && gem install bundler \
-    && bundle install \
-    && bundle exec jekyll clean \
-    && bundle exec jekyll build \
-    && gem cleanup \
-    && apk del build-dependencies 
-
-EXPOSE 4000
+FROM nginx:alpine
+COPY --from=builder /site/_site /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -3,10 +3,8 @@ This is the official repository of the Flux Hochschulgruppe at KIT.
 Are you looking to join us? [This](https://matrix.to/#/#perpetuum-mobile:matrix.perpetuum-mobile.space) is our matrix space.
 
 ## Development
-To develop this site you require jekyll and docker compose. On NixOS you can use the provided flake (`nix develop`).
+To develop this site you require jekyll. On NixOS you can use the provided flake (`nix develop`).
 On other systems you need to install this manually.
-
-Run `docker compose up` to spin up a temporary development server.
 
 ## Contributions
 This is a repository for our web infastructure. PRs from people unknown to the maintainers will be rejected without further comment.


### PR DESCRIPTION
The current docker image has a few issues:

1. Bad caching leading to annoying slow build times
2. It is bloated by shipping all of jekyll, ruby, etc.
3. `jekyll serve` has issues, such as not serving a proper production build, leading to the served HTML giving a bad canonical URL for example (bad for SEO) and generally not being a production-ready HTTP server
4. `jekyll serve` runs as root, and is generally not meant to be user-facing, so it's potentially dangerous

This PR:

- Adds proper caching layers to speed up rebuilds
- Uses a builder container to avoid shipping unnecessary bloat with the image
- Uses `nginxinc/nginx-unprivileged:alpine` to serve the built website