### PR TITLE
fix: Attempt to make chaos.social verification work

### DIFF
--- a/site/_data/contact.yml
+++ b/site/_data/contact.yml
@@ -7,9 +7,9 @@
 # Uncomment and complete the url below to enable more contact options
 
 - type: mastodon
-  icon: 'fab fa-mastodon'   # icons powered by <https://fontawesome.com/>
-  url:  'https://chaos.social/@flux_ka/'
+  icon: "fab fa-mastodon" # icons powered by <https://fontawesome.com/>
+  url: "https://chaos.social/@Flux_ka"
 
 - type: instagram
-  icon: 'fab fa-instagram'
-  url: 'https://www.instagram.com/flux_ka'
+  icon: "fab fa-instagram"
+  url: "https://www.instagram.com/flux_ka"

--- a/site/_includes/metadata-hook.html
+++ b/site/_includes/metadata-hook.html
@@ -1,0 +1,1 @@
+<meta name="fediverse:creator" content="@Flux_ka@chaos.social" />


### PR DESCRIPTION
We are not registering as verified through the website on Mastodon - I tried putting the exact URL Mastodon asks one to put in to see if that fixes it. The rel=me is already added by the jekyll theme, but it might be that additional HTML attributes trips mastodon up, in which case if this PR doesn't fix the issue, we should take a look at adding an invisible tag the exact way Mastodon likes it.

Additionally, I marked flux's mastodon account as the author of all of our pages, so anytime someone links to us in the fediverse, our account will also be displayed in the embed card.