### PR TITLE
fix: Use jekyll 404 page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,5 @@ RUN --mount=type=cache,target=/site/.jekyll-cache \
     JEKYLL_ENV=production bundle exec jekyll build
 
 FROM nginxinc/nginx-unprivileged:alpine
+COPY site/nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=builder /site/_site /usr/share/nginx/html

--- a/site/nginx.conf
+++ b/site/nginx.conf
@@ -1,6 +1,10 @@
 server {
   listen 8080;
-  server_name flux-website;
+
+  server_name flux-ka.de;
+  port_in_redirect off;
+  server_name_in_redirect on;
+  absolute_redirect on;
 
   location / {
     root /usr/share/nginx/html;

--- a/site/nginx.conf
+++ b/site/nginx.conf
@@ -1,0 +1,12 @@
+server {
+  listen 8080;
+  server_name flux-website;
+
+  location / {
+    root /usr/share/nginx/html;
+    index index.html;
+  }
+
+  error_page 404 /404.html;
+  error_page 500 502 503 504 /50x.html;
+}


### PR DESCRIPTION
nginx's docker image did not use our 404.html file by default, so we need to replace it with a custom nginx configuration


EDIT: Also fixed redirects